### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/ianguffick/3fca4b2f-70e0-4e3a-914c-0fd8230d9b2b/cfdc4360-23fe-4817-9ba9-ab4b450ca4ff/_apis/work/boardbadge/8d4ab0bb-bf02-4b81-b276-d16f09367af0)](https://dev.azure.com/ianguffick/3fca4b2f-70e0-4e3a-914c-0fd8230d9b2b/_boards/board/t/cfdc4360-23fe-4817-9ba9-ab4b450ca4ff/Microsoft.RequirementCategory)
 # repo-for-boards
 The first Git Repo to integrate with Azure Boards


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/ianguffick/3fca4b2f-70e0-4e3a-914c-0fd8230d9b2b/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.